### PR TITLE
#1 fix

### DIFF
--- a/jagaximo/index.md
+++ b/jagaximo/index.md
@@ -487,7 +487,7 @@ object TwitterPassion extends Serializable with App {
 
 次は、いよいよクラスタの動かし方に入って行きましょう。
 
-## クラスターで動かす
+## クラスタで動かす
 
 ここからはSparkの本懐であるクラスタ動作を行っていきたいと思います。
 


### PR DESCRIPTION
統一して書いてるつもりだったからショックや……

``` bash
/Users/jagaximo/Documents/C88% ag "クラスタ" | wc -l            (git)-[fix/spelling-inconsistency]
      27
/Users/jagaximo/Documents/C88% ag "クラスタ-" | wc -l           (git)-[fix/spelling-inconsistency]
       0
/Users/jagaximo/Documents/C88% ag "クラスター" | wc -l          (git)-[fix/spelling-inconsistency]
       0
/Users/jagaximo/Documents/C88%                                  (git)-[fix/spelling-inconsistency]
```
### reviewer
- [x] @tboffice 
